### PR TITLE
Fix usage of lhs in ActiveParser

### DIFF
--- a/library/Vanda/Grammar/XRS/LCFRS/ActiveParser.hs
+++ b/library/Vanda/Grammar/XRS/LCFRS/ActiveParser.hs
@@ -239,7 +239,7 @@ completionRule word ios = Right app
         | range' <- maybeToList $ safeConc range (rv ! j)
         , let c' = IMap.insert i rv c
               inside = aiw <.> (piw </> fst (ios Map.! a))
-              outside = snd $ ios Map.! lhs r
+              outside = snd $ ios Map.! lhs (r,w)
         , (rho', f') <- completeKnownTokens word c' (range':rho) (fs:fss)
         ]
     consequences _ _ = []


### PR DESCRIPTION
Need weight of `Rule` too when using PMCFG.lhs